### PR TITLE
fix: don't assume all avatar entities are players

### DIFF
--- a/src/main/java/net/uku3lig/bettershields/mixin/MixinPlayerItemInHandLayer.java
+++ b/src/main/java/net/uku3lig/bettershields/mixin/MixinPlayerItemInHandLayer.java
@@ -9,6 +9,7 @@ import net.minecraft.client.renderer.item.ItemStackRenderState;
 import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.uku3lig.bettershields.BetterShields;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -20,6 +21,9 @@ public class MixinPlayerItemInHandLayer {
     @Inject(method = "submitArmWithItem(Lnet/minecraft/client/renderer/entity/state/AvatarRenderState;Lnet/minecraft/client/renderer/item/ItemStackRenderState;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/HumanoidArm;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;I)V",
     at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/layers/ItemInHandLayer;submitArmWithItem(Lnet/minecraft/client/renderer/entity/state/ArmedEntityRenderState;Lnet/minecraft/client/renderer/item/ItemStackRenderState;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/HumanoidArm;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;I)V"))
     public void fetchCurrentRenderedPlayer(AvatarRenderState avatarRenderState, ItemStackRenderState itemStackRenderState, ItemStack itemStack, HumanoidArm humanoidArm, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int i, CallbackInfo ci) {
-        BetterShields.setCurrentRenderedPlayer((Player) Minecraft.getInstance().level.getEntity(avatarRenderState.id));
+        Level level = Minecraft.getInstance().level;
+        if (level != null && level.getEntity(avatarRenderState.id) instanceof Player player) {
+            BetterShields.setCurrentRenderedPlayer(player);
+        }
     }
 }


### PR DESCRIPTION
fixed unsafe casting to player: entity can be ClientMannequinEntity in 1.21.11